### PR TITLE
sgraph-js graph improvements

### DIFF
--- a/samples/sgraph-js/globals.js
+++ b/samples/sgraph-js/globals.js
@@ -8,6 +8,7 @@ const sort_filter = document.getElementById('sort-filter');
 const center_view = document.getElementById('center-view');
 const prop_filter_exported = document.getElementById('prop-filter-exported');
 const prop_filter_non_exported = document.getElementById('prop-filter-non-exported');
+const narrow_graph_context = document.getElementById('filter-narrow-context');
 
 // Options dialog
 const decl_color_dropdown = document.getElementById('decl-color-dropdown');
@@ -20,6 +21,7 @@ const reset_class_colors_btn = document.getElementById('reset-class-colors');
 const filter_opacity_edit = document.getElementById('filter-opacity-edit');
 const bad_filter_opacity_text = document.getElementById('bad-filter-opacity-text');
 const graph_fps_toggle = document.getElementById('graph-fps-toggle');
+const graph_animations = document.getElementById('graph-animations');
 
 // IFC explorer dialog
 const ifc_explorer = {
@@ -59,6 +61,24 @@ const ifc_explorer = {
 };
 
 // Scripting globals
-var graph_filter = new GraphFilter();
+var graph = {
+    data: {
+        original_data: null
+    },
+    drawing: {
+        native_width: 1260.0,
+        native_height: 800.0,
+        custom_base_element: null,
+        working_data: null,
+        last_update_time: 0,
+        timer: null,
+        canvas_dirty: false,
+        backing_canvas_dirty: false,
+        node_mapper: null,
+        partition: null
+    },
+    element: document.getElementById('icicle')
+};
+var graph_filter = null;
 var options = null;
 var sgraph = { resolver: null, header: null };

--- a/samples/sgraph-js/index.html
+++ b/samples/sgraph-js/index.html
@@ -149,6 +149,9 @@
                         <label class="btn btn-secondary active">
                             <input id="graph-fps-toggle" type="checkbox"> Graph draw FPS
                         </label>
+                        <label class="btn btn-secondary active">
+                            <input id="graph-animations" type="checkbox"> Disable graph animations
+                        </label>
                         <div class="input-group input-group-sm">
                             <div class="input-group-prepend">
                                 <span class="input-group-text">Filtered opacity %</span>
@@ -267,6 +270,11 @@
             <input id="name-filter" type="text" />
             <div>Filter Types:</div>
             <select id="sort-filter"></select>
+            <div class="row-sm-2 pt-1">
+                <label class="btn btn-secondary btn-sm active">
+                    <input id="filter-narrow-context" type="checkbox"> Narrow graph to filter</input>
+                </label>
+            </div>
             <br>
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-slash-fill" viewBox="0 0 16 16">
                 <path d="m10.79 12.912-1.614-1.615a3.5 3.5 0 0 1-4.474-4.474l-2.06-2.06C.938 6.278 0 8 0 8s3 5.5 8 5.5a7.029 7.029 0 0 0 2.79-.588zM5.21 3.088A7.028 7.028 0 0 1 8 2.5c5 0 8 5.5 8 5.5s-.939 1.721-2.641 3.238l-2.062-2.062a3.5 3.5 0 0 0-4.474-4.474L5.21 3.089z"/>
@@ -288,7 +296,7 @@
         </nav>
         <div class="content-container">
             <div id="breadcrumb"></div>
-            <div id="icicle"></div>
+            <div id="icicle" hidden></div>
         </div>
     </div>
 
@@ -297,6 +305,9 @@
     <script src="https://d3js.org/d3.v6.min.js"></script>
     <!-- Note: bootstrap.js must be loaded after JQuery as it depends on JQuery -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.min.js" integrity="sha384-+YQ4JLhjyBLPDQt//I+STsc9iw4uQqACwlvpslubQzn4u2UU2UFM80nGisd026JF" crossorigin="anonymous"></script>
+
+    <!-- Shared scripts -->
+    <script type='text/javascript' src='globals.js'></script>
 
     <!-- Core -->
     <script type='text/javascript' src='sgraph/decls.js'></script>
@@ -308,6 +319,7 @@
     <script type='text/javascript' src='sgraph/resolve.js'></script>
     <script type='text/javascript' src='sgraph/sgraph.js'></script>
     <script type='text/javascript' src='sgraph/types.js'></script>
+    <script type='text/javascript' src='sgraph/util.js'></script>
 
     <!-- UI Helpers -->
     <script type='text/javascript' src='ui/filter.js'></script>
@@ -317,7 +329,6 @@
     <script type='text/javascript' src='ui/sidebar.js'></script>
 
     <!-- Startup -->
-    <script type='text/javascript' src='globals.js'></script>
     <script type='text/javascript' src='loader.js'></script>
   </body>
 </html>

--- a/samples/sgraph-js/loader.js
+++ b/samples/sgraph-js/loader.js
@@ -1,7 +1,3 @@
-function has_property(obj, prop) {
-    return obj.hasOwnProperty(prop);
-}
-
 function log_header(header) {
     if (!header.valid())
         console.log("not valid header!");
@@ -152,7 +148,7 @@ function on_decl_selected(decl) {
     const basic_spec = format_basic_spec(symbolic_decl);
     const json_str = JSON.stringify(symbolic_decl, null, 2);
     set_decl_preview_content("<pre>" + `${decl_index_str}\n${basic_spec}\n${locus_str}\n` + json_str + "</pre>");
-    set_ifc_explorer_selected_decl(resolved_name.index, false);
+    set_ifc_explorer_selected_decl(resolved_name.index, false, SkipNavigation);
 }
 
 function init_sgraph(resolver, header) {
@@ -256,6 +252,7 @@ if (window.FileList && window.File) {
             read_ifc(reader, header);
             display_ifc_info(file);
             ifc_explorer_ifc_loaded();
+            graph.element.hidden = false;
         });
         reader.readAsArrayBuffer(file);
     });

--- a/samples/sgraph-js/sgraph/decls.js
+++ b/samples/sgraph-js/sgraph/decls.js
@@ -116,6 +116,7 @@ class ScopeDecl {
         this.alignment = new ExprIndex(reader);
         this.pack_size = reader.read_uint16();
         this.basic_spec = new BasicSpecifiers(reader);
+        this.scope_spec = new ScopeTraits(reader);
         this.access = new Access(reader);
         this.properties = new ReachableProperties(reader);
     }

--- a/samples/sgraph-js/sgraph/sgraph.js
+++ b/samples/sgraph-js/sgraph/sgraph.js
@@ -507,6 +507,22 @@ class BasicSpecifiers {
     }
 }
 
+class ScopeTraits {
+    static Values = {
+        None:                0,
+        Unnamed:             1 << 0,       // unnamed namespace, or unnamed class types.
+        Inline:              1 << 1,       // inline namespace.
+        InitializerExported: 1 << 2,       // This object has its initializer exported
+        ClosureType:         1 << 3,       // lambda-like scope
+        Final:               1 << 4,       // a derived class marked as 'final'
+        Vendor:              1 << 7        // The scope has extended vendor specific traits
+    };
+
+    constructor(reader) {
+        this.value = reader.read_uint8();
+    }
+};
+
 class ObjectTraits {
     static Values = {
         None:                0,

--- a/samples/sgraph-js/sgraph/util.js
+++ b/samples/sgraph-js/sgraph/util.js
@@ -1,0 +1,23 @@
+function has_property(obj, prop) {
+    return obj.hasOwnProperty(prop);
+}
+
+function is_object(obj) {
+    return typeof obj === 'object';
+}
+
+function remove_all_children(content) {
+    // Yes, it is intentional to check for the first and remove the last.
+    while (content.firstChild != null) {
+        content.removeChild(content.lastChild);
+    }
+}
+
+// Implementation pulled from: https://www.freecodecamp.org/news/javascript-debounce-example/
+function debounce(func, timeout = 300) {
+    let timer = undefined;
+    return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => { func.apply(this, args); }, timeout);
+    };
+}

--- a/samples/sgraph-js/ui/filter.js
+++ b/samples/sgraph-js/ui/filter.js
@@ -10,6 +10,7 @@ class GraphFilter {
         this.name = '';
         this.sort = -1;
         this.prop_filters = PropertyFilters.None;
+        this.narrow_context = false;
     }
 
     reset() {
@@ -97,7 +98,19 @@ function toggle_filter_non_exported_decls(e, checkbox) {
     apply_graph_filter(graph_filter);
 }
 
+function toggle_narrow_graph_context(e, checkbox) {
+    graph_filter.narrow_context = checkbox.checked;
+    // If this becomes 'unchecked' then we need to rebuild the graph
+    // so the filter overlay shows every node.
+    if (!graph_filter.narrow_context) {
+        rebuild_original_graph();
+    }
+    apply_graph_filter(graph_filter);
+}
+
 function init_filters() {
+    graph_filter = new GraphFilter();
+
     populate_sort_filter();
 
     name_filter.addEventListener("keyup", event => filter_names_keyup(event, name_filter));
@@ -106,4 +119,5 @@ function init_filters() {
     center_view.addEventListener("click", e => reset_view());
     prop_filter_exported.addEventListener("click", event => toggle_filter_exported_decls(event, prop_filter_exported));
     prop_filter_non_exported.addEventListener("click", event => toggle_filter_non_exported_decls(event, prop_filter_non_exported));
+    narrow_graph_context.addEventListener("click", event => toggle_narrow_graph_context(event, narrow_graph_context));
 }

--- a/samples/sgraph-js/ui/graph.js
+++ b/samples/sgraph-js/ui/graph.js
@@ -1,31 +1,28 @@
 // D3 + HTML canvas: https://www.freecodecamp.org/news/d3-and-canvas-in-3-steps-8505c8b27444
 
-var native_width = 1260.0;
-var native_height = 800.0;
-
 function transposed() {
     return options != null && options.transpose;
 }
 
 function height() {
     if (transposed()) {
-        return native_width;
+        return graph.drawing.native_width;
     }
-    return native_height;
+    return graph.drawing.native_height;
 }
 
 function width() {
     if (transposed())
-        return native_height;
-    return native_width;
+        return graph.drawing.native_height;
+    return graph.drawing.native_width;
 }
 
 var x = d3.scaleLinear()
-          .range([0.0, native_width])
+          .range([0.0, graph.drawing.native_width])
           .domain([0.0, 1.0]); // TODO
 
 var y = d3.scaleLinear()
-          .range([0.0, native_height])
+          .range([0.0, graph.drawing.native_height])
           .domain([0.0, 1.0]); // TODO
 
 function zoom_filter(event) {
@@ -36,21 +33,27 @@ function zoom_filter(event) {
 
 var zoom = d3.zoom()
              .filter(zoom_filter)
-             .on("zoom", zoomed);
+             // Delay the 'zoomed' callback so we don't modify a large data model hundreds of times
+             // in a second.
+             .on("zoom", debounce(zoomed));
 
 var graph_canvas = d3.select("#icicle")
                      .append("canvas")
                      .classed("graph-canvas", true)
-                     .attr("width", native_width)
-                     .attr("height", native_height)
+                     .attr("width", graph.drawing.native_width)
+                     .attr("height", graph.drawing.native_height)
                      .call(zoom)
                      .on("dblclick.zoom", null);
+
+var render_canvas = d3.select(document.createElement("canvas"))
+                      .attr("width", graph.drawing.native_width)
+                      .attr("height", graph.drawing.native_height);
 
 var backing_canvas = d3.select("#icicle")
                        .append("canvas")
                        .classed("backing-graph-canvas", true)
-                       .attr("width", native_width)
-                       .attr("height", native_height)
+                       .attr("width", graph.drawing.native_width)
+                       .attr("height", graph.drawing.native_height)
                        .attr("hidden", true);
 
 class PartitionDataHelper
@@ -69,17 +72,12 @@ class PartitionDataHelper
     }
 }
 
-var partition = null;
-
 // Breadcrumb dimensions: width, height, spacing, width of tip/tail.
 var b = {
     w: 150, h: 30, s: 3, t: 10
 };
 
 var total_size = 0;
-
-var custom_data_base = document.createElement("custom");
-var custom_data = d3.select(custom_data_base);
 
 const delim = '`_';
 function is_meta_name(name) {
@@ -201,15 +199,12 @@ function draw_fps(context, fps) {
     context.fillText(`FPS (average): ${fps_avg}`, 50, 70);
 }
 
-function draw(canvas, is_backing_canvas, fps) {
-    var context = canvas.node().getContext("2d");
-
-    context.clearRect(0, 0, native_width, native_height);
-
-    context.font = "14px serif";
-
+function render_nodes(canvas) {
+    var render_ctx = canvas.getContext("2d");
+    render_ctx.clearRect(0, 0, graph.drawing.native_width, graph.drawing.native_height);
+    render_ctx.font = "14px serif";
     var rect = { left: null, top: null, height: null, width: null };
-    for (var node of custom_data) {
+    for (var node of graph.drawing.working_data) {
         rect.left = parseInt(node.getAttribute("x"));
         rect.top = parseInt(node.getAttribute("y"));
         // Take the max between the height/width and 1px so the viewer has some
@@ -219,16 +214,91 @@ function draw(canvas, is_backing_canvas, fps) {
 
         const selected = node.getAttribute("selected") == "true";
 
-        if (!is_backing_canvas)
-            draw_node(context, node, rect, selected);
-        // Note: we only want to draw the backing rect if the node is selected.  This
-        // will prevent mouse interactivity on the 'unselected' rects.
-        else if (selected)
-            draw_backing_rect(context, node, rect);
+        draw_node(render_ctx, node, rect, selected);
+    }
+    // If the nodes are ever rendered, the backing canvas is implicitly dirty.
+    backing_canvas_dirty = true;
+}
+
+const text_box_height = 20;
+// +2 padding pixels.
+const text_box_padding = 2;
+
+function draw_text_box_at(context, text, point) {
+    const measured = context.measureText(text);
+    var rect = { left: null, top: null, height: null, width: null };
+    rect.width = measured.width + text_box_padding;
+    rect.height = text_box_height;
+    rect.left = point.x;
+    rect.top = point.y;
+    // We want to ensure the text box is visible.  If it exceeds the viewable canvas area
+    // we will recenter it.
+    // x first.
+    if (rect.left + rect.width > graph.drawing.native_width) {
+        // Anchor to the side.
+        rect.left = graph.drawing.native_width - rect.width;
+    }
+    // y next.
+    if (rect.top < 0) {
+        // Anchor to the top.
+        rect.top = 0;
+    }
+    context.fillStyle = "#ffffff";
+    context.fillRect(rect.left, rect.top, rect.width, rect.height);
+    context.strokeStyle = "#000000";
+    context.strokeRect(rect.left, rect.top, rect.width, rect.height);
+    context.fillStyle = "#000000";
+    context.fillText(text, rect.left + 1, rect.top + 14, rect.width);
+    return rect;
+}
+
+function draw_node_hover(context, hover) {
+    const text = `${hover.name} : ${hover.index}`;
+    var point = {
+                // Add padding away from mouse cursor.
+                x: hover.x + text_box_padding,
+                // Float above the cursor.
+                y: hover.y - text_box_height - text_box_padding };
+    draw_text_box_at(context, text, point);
+}
+
+function draw(canvas, is_backing_canvas, fps) {
+    var context = canvas.node().getContext("2d");
+
+    context.clearRect(0, 0, graph.drawing.native_width, graph.drawing.native_height);
+
+    context.font = "14px serif";
+
+    if (is_backing_canvas) {
+        var rect = { left: null, top: null, height: null, width: null };
+        for (var node of graph.drawing.working_data) {
+            rect.left = parseInt(node.getAttribute("x"));
+            rect.top = parseInt(node.getAttribute("y"));
+            // Take the max between the height/width and 1px so the viewer has some
+            // visual indication that _something_ is in this region.
+            rect.height = Math.max(parseInt(node.getAttribute("height")), 1);
+            rect.width = Math.max(parseInt(node.getAttribute("width")), 1);
+
+            const selected = node.getAttribute("selected") == "true";
+
+            // Note: we only want to draw the backing rect if the node is selected.  This
+            // will prevent mouse interactivity on the 'unselected' rects.
+            if (selected)
+                draw_backing_rect(context, node, rect);
+        }
+        return;
     }
 
-    if (is_backing_canvas)
-        return;
+    var render_canvas_element = render_canvas.node();
+    if (canvas_dirty && !is_backing_canvas)
+        render_nodes(render_canvas_element);
+    // Note: we apply the render canvas to the native width/height because we've possibly downscaled it
+    // based on DPI settings.
+    context.drawImage(render_canvas_element, 0, 0, graph.drawing.native_width, graph.drawing.native_height);
+
+    if (hovered_node != null)
+        draw_node_hover(context, hovered_node);
+
     if (options != null && options.show_fps)
         draw_fps(context, fps);
 }
@@ -282,17 +352,10 @@ class NodeToColorMapper {
     }
 }
 
-var node_mapper = new NodeToColorMapper();
+var canvas_dirty = false;
+var backing_canvas_dirty = false;
 
 var last_update_time = 0;
-var timer = d3.timer(function(elapsed) {
-    // Aim for 60fps.
-    if (elapsed - last_update_time > 16) {
-        var fps = 1000 / (elapsed - last_update_time);
-        draw(graph_canvas, false, fps);
-        last_update_time = elapsed;
-    }
-});
 
 function map_object(o) {
     return { key: o[0], value: o[1] };
@@ -334,17 +397,30 @@ function transform_node_height(d, t) {
     return t(d.y1) - t(d.y0);
 }
 
-function init_graph(root) {
+function setup_dpi(canvas) {
+    // Reference: https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas#scaling_for_high_resolution_displays
+    canvas.style.width = `${graph.drawing.native_width}px`;
+    canvas.style.height = `${graph.drawing.native_height}px`;
+
+    var dpr = window.devicePixelRatio || 1;
+    canvas.width = graph.drawing.native_width * dpr;
+    canvas.height = graph.drawing.native_height * dpr;
+    var dpr = window.devicePixelRatio || 1;
+    var context = canvas.getContext("2d");
+    context.scale(dpr, dpr);
+}
+
+function build_graph_data(root) {
     root = d3.hierarchy(Object.entries(root).map(map_object)[0], function(d) {
             return Object.entries(d.value).map(map_object);
         })
         .sum(function(d) { return d.value })
         .sort(function(a, b) { return b.value - a.value; });
 
-    partition = new PartitionDataHelper(root);
+    graph.drawing.partition = new PartitionDataHelper(root);
+    graph.drawing.node_mapper = new NodeToColorMapper();
 
-    partition.partition();
-    init_breadcrumb_trail();
+    graph.drawing.partition.partition();
     var percentage = 100;
     var percentageString = percentage + "%";
 
@@ -357,7 +433,10 @@ function init_graph(root) {
     var sequenceArray = root.ancestors().reverse();
     update_breadcrumbs(sequenceArray, percentageString);
 
-    custom_data = custom_data.selectAll("custom.rect")
+    graph.drawing.custom_base_element = document.createElement("custom");
+    graph.drawing.working_data = d3.select(graph.drawing.custom_base_element);
+
+    graph.drawing.working_data = graph.drawing.working_data.selectAll("custom.rect")
                              .data(root.descendants())
                              .enter()
                              .append("custom")
@@ -369,11 +448,32 @@ function init_graph(root) {
                              .attr("fill", function(d) { return color_from_meta(d.data.key); })
                              .attr("gradient-fill", function(d) { return secondary_color_from_meta(d.data.key); })
                              .attr("node-name", function(d) { return name_from_meta(d.data.key); })
-                             .attr("backing-fill", function(d) { return node_mapper.map_node(d); })
+                             .attr("backing-fill", function(d) { return graph.drawing.node_mapper.map_node(d); })
                              .attr("selected", function(d) { return true; });
 
     //get total size from rect
-    total_size = custom_data.node().__data__.value;
+    total_size = graph.drawing.working_data.node().__data__.value;
+}
+
+function init_graph(root) {
+    graph.data.original_data = root;
+    setup_dpi(graph_canvas.node());
+    setup_dpi(render_canvas.node());
+    init_breadcrumb_trail();
+    // Note: we do not scale the backing-canvas because its size needs to correspond directly to unscaled
+    // mouse coordinates on screen.
+    build_graph_data(root);
+
+    requestAnimationFrame(animation_frame);
+    function animation_frame(elapsed) {
+        // Aim for 60fps.
+        if (elapsed - last_update_time > 16) {
+            var fps = 1000 / (elapsed - last_update_time);
+            draw(graph_canvas, false, fps);
+            last_update_time = elapsed;
+        }
+        requestAnimationFrame(animation_frame);
+    }
 
     // Center the view on the top-most node.
     reset_view();
@@ -383,37 +483,104 @@ function zoomed(e) {
     var new_x = e.transform.rescaleX(x);
     var new_y = e.transform.rescaleY(y);
 
-    custom_data.transition()
-               .duration(750)
-               .attr("x", function(d) { return new_x(node_x(d)); })
-               .attr("y", function(d) { return new_y(node_y(d)); })
-               .attr("width", function(d) { return transform_node_width(d, new_x); })
-               .attr("height", function(d) { return transform_node_height(d, new_y); });
+    if (options.graph_animations)
+    {
+        canvas_dirty = true;
+        graph.drawing.working_data.transition()
+                   .duration(750)
+                   .attr("x", function(d) { return new_x(node_x(d)); })
+                   .attr("y", function(d) { return new_y(node_y(d)); })
+                   .attr("width", function(d) { return transform_node_width(d, new_x); })
+                   .attr("height", function(d) { return transform_node_height(d, new_y); })
+                   .end()
+                        .then(() => {
+                            canvas_dirty = false;
+                            // Make sure that we show the nodes in their final position.
+                            render_nodes(render_canvas.node()); } )
+                        .catch(() => {});
+    }
+    else
+    {
+        graph.drawing.working_data
+            .attr("x", function(d) { return new_x(node_x(d)); })
+            .attr("y", function(d) { return new_y(node_y(d)); })
+            .attr("width", function(d) { return transform_node_width(d, new_x); })
+            .attr("height", function(d) { return transform_node_height(d, new_y); });
+        render_nodes(render_canvas.node());
+    }
+}
+
+function screen_space_to_point(event) {
+    // https://stackoverflow.com/a/12114213
+    // The ordering of layer vs offset is important.  We want to prefer
+    // offset if we can as this is the position of the mouse in the
+    // canvas bounding box.
+    const mouse_x = event.offsetX || event.layerX;
+    const mouse_y = event.offsetY || event.layerY;
+    return { x: mouse_x, y: mouse_y };
+}
+
+function extract_node_from_backing_canvas(point) {
+    const backing_canvas_context = backing_canvas.node().getContext("2d");
+    const color = backing_canvas_context.getImageData(point.x, point.y, 1, 1).data;
+    const key = CanvasColorGenerator.key(color[0], color[1], color[2]);
+
+    const node = graph.drawing.node_mapper.get(key);
+    return node;
+}
+
+function rebuild_backing_canvas_if_necessary() {
+    if (backing_canvas_dirty) {
+        console.log("backing canvas refreshed");
+        draw(backing_canvas, true);
+        backing_canvas_dirty = false;
+    }
 }
 
 d3.select(".graph-canvas")
   .on("click", function(e) {
     // Render the backing canvas to get the correct color.
-    draw(backing_canvas, true);
-
-    // https://stackoverflow.com/a/12114213
-    // The ordering of layer vs offset is important.  We want to prefer
-    // offset if we can as this is the position of the mouse in the
-    // canvas bounding box.
-    const mouse_x = e.offsetX || e.layerX;
-    const mouse_y = e.offsetY || e.layerY;
-
-    const backing_canvas_context = backing_canvas.node().getContext("2d");
-    const color = backing_canvas_context.getImageData(mouse_x, mouse_y, 1, 1).data;
-    const key = CanvasColorGenerator.key(color[0], color[1], color[2]);
-
-    const node = node_mapper.get(key);
+    rebuild_backing_canvas_if_necessary();
+    const point = screen_space_to_point(e);
+    const node = extract_node_from_backing_canvas(point);
     if (node == null)
         return;
-    clicked(node);
+    navigate_to(node);
 });
 
-function clicked(d) {
+var hovered_node = null;
+d3.select(".graph-canvas")
+    .on("mousemove", function(e) {
+        rebuild_backing_canvas_if_necessary();
+        const point = screen_space_to_point(e);
+        const node = extract_node_from_backing_canvas(point);
+        if (node == null) {
+            hovered_node = null;
+            return;
+        }
+        // If we're pointing at the same node as before, we don't need to update the node, just the position.
+        if (hovered_node != null && hovered_node.node == node)
+        {
+            hovered_node.x = point.x;
+            hovered_node.y = point.y;
+            return;
+        }
+
+        var index = "N/A";
+        var name = "N/A";
+        if (node.data.name != "root" && is_meta_name(node.data.key)) {
+            var meta = name_and_index_from_meta(node.data.key);
+            index = `DeclIndex{${sort_to_string(DeclIndex, meta.index.sort)},${meta.index.index}}`;
+            name = `${meta.name}`;
+        }
+        console.log("new hover node");
+        hovered_node = { node: node, index: index, name: name, x: point.x, y: point.y };
+});
+
+// A helper to skip the 'decl_selected' callback during 'navigate_to'.
+const SkipSelection = {};
+
+function navigate_to(d, skip_selection) {
     if (transposed()) {
         x.domain([d.y0, height()]).range([d.depth ? 20 : 0, height()]);
         y.domain([d.x0, d.x1]);
@@ -423,16 +590,40 @@ function clicked(d) {
         y.domain([d.y0, height()]).range([d.depth ? 20 : 0, height()]);
     }
 
-    // Adjust the zoom transform so that zooming will work smoothly around the newly
-    // centered node.  Solution from: https://github.com/d3/d3-zoom/issues/107.
-    zoom.transform(graph_canvas, d3.zoomIdentity);
-
-    custom_data.transition()
-               .duration(750)
-               .attr("x", function(d) { return x(node_x(d)); })
-               .attr("y", function(d) { return y(node_y(d)); })
-               .attr("width", function(d) { return transform_node_width(d, x); })
-               .attr("height", function(d) { return transform_node_height(d, y); });
+    if (options.graph_animations)
+    {
+        canvas_dirty = true;
+        graph.drawing.working_data.transition()
+                   .duration(750)
+                   .attr("x", function(d) { return x(node_x(d)); })
+                   .attr("y", function(d) { return y(node_y(d)); })
+                   .attr("width", function(d) { return transform_node_width(d, x); })
+                   .attr("height", function(d) { return transform_node_height(d, y); })
+                   .end()
+                        .then(() => {
+                            canvas_dirty = false;
+                            // Make sure that we show the nodes in their final position.
+                            render_nodes(render_canvas.node()); } )
+                        .catch(() => {})
+                        .finally(() => 
+                            // Adjust the zoom transform so that zooming will work smoothly around the newly
+                            // centered node.  Solution from: https://github.com/d3/d3-zoom/issues/107.
+                            // Note: do this after the transition to the clicked node so that the even that fires
+                            // after the transition is modified will do minimal work.
+                            zoom.transform(graph_canvas, d3.zoomIdentity));
+    }
+    else
+    {
+        graph.drawing.working_data
+            .attr("x", function(d) { return x(node_x(d)); })
+            .attr("y", function(d) { return y(node_y(d)); })
+            .attr("width", function(d) { return transform_node_width(d, x); })
+            .attr("height", function(d) { return transform_node_height(d, y); });
+        render_nodes(render_canvas.node());
+        // Adjust the zoom transform so that zooming will work smoothly around the newly
+        // centered node.  Solution from: https://github.com/d3/d3-zoom/issues/107.
+        zoom.transform(graph_canvas, d3.zoomIdentity);
+    }
 
     // code to update the BreadcrumbTrail();
     var percentage = (100 * d.value / total_size).toPrecision(3);
@@ -447,18 +638,24 @@ function clicked(d) {
     d3.select("#explanation")
         .style("visibility", "");
 
-    var sequenceArray = d.ancestors().reverse();
+    const sequenceArray = d.ancestors().reverse();
     update_breadcrumbs(sequenceArray, percentageString);
 
+    if (skip_selection != undefined && skip_selection == SkipSelection)
+        return;
     // We only want to fire the handler when a node is actually clicked (in this handler).
     decl_selected(sequenceArray);
+}
+
+function clicked(d) {
+    navigate_to(d);
 }
 
 function init_breadcrumb_trail() {
     // Add the svg area.
     var trail = d3.select("#breadcrumb")
                   .append("svg")
-                  .attr("width", native_width)
+                  .attr("width", graph.drawing.native_width)
                   .attr("height", 50)
                   .attr("id", "trail");
     // Add the label at the end, for the percentage.
@@ -547,55 +744,162 @@ function filtered_by_property(property_filter, index) {
     return implies(property_filter, PropertyFilters.Exported);
 }
 
+function meta_name_filtered(meta_name, filter) {
+    // Filter out all meta 'names' which are not actual meta names.
+    if (!is_meta_name(meta_name))
+        return true;
+    meta = name_and_index_from_meta(meta_name);
+    if (filter.filter_sort()) {
+        if (meta.index.sort != filter.sort)
+            return true;
+    }
+
+    if (filter.filter_name()) {
+        var name = meta.name;
+        if (filter.name != name)
+            return true;
+    }
+
+    if (filter.filter_props() != PropertyFilters.None)
+        return filtered_by_property(filter.filter_props(), meta.index);
+    return false;
+}
+
+function new_node_for(node) {
+    var new_node = { name: node[0], value: { } };
+    return new_node;
+}
+
+function merge_node_properties(node, props) {
+    for (var p of props) {
+        node.value[p.name] = p.value;
+    }
+}
+
+// Walk the graph and prune subtrees, returning a new graph.
+function walk_and_filter(node, filter) {
+    const children = Object.entries(node[1]);
+    // Leaf node.
+    if (children.length == 0) {
+        if (meta_name_filtered(node[0], filter)) {
+            return null;
+        }
+        var new_node = new_node_for(node);
+        new_node.value = 1;
+        return new_node;
+    }
+    const new_children = children
+                        .map(e => walk_and_filter(e, filter))
+                        .filter(e => e != null);
+    var new_node = new_node_for(node);
+    if (new_children.length == 0) {
+        if (meta_name_filtered(node[0], filter))
+            return null;
+        new_node.value = 1;
+        return new_node;
+    }
+    merge_node_properties(new_node, new_children);
+    return new_node;
+}
+
+function prune_with_graph_filter(filter) {
+    // This algorithm will more-or-less perform a copy-on-write of nodes within the current graph.  If a node or its children
+    // do not meet the filter criteria, it will be pruned.
+    var new_root = { global: { } };
+    const new_root_children = Object
+                                .entries(graph
+                                            .data
+                                            .original_data
+                                            .global)
+                                .map(e => walk_and_filter(e, filter))
+                                .filter(e => e != null);
+    for (var p of new_root_children) {
+        new_root.global[p.name] = p.value;
+    }
+    build_graph_data(new_root);
+    reset_view();
+}
+
+function rebuild_original_graph() {
+    build_graph_data(graph.data.original_data);
+    reset_view();
+}
+
 function apply_graph_filter(filter) {
     if (filter.empty()) {
-        custom_data.attr("selected", function(d) { return true; });
+        build_graph_data(graph.data.original_data);
+        graph.drawing.working_data.attr("selected", function(d) {
+            return true;
+        });
+        reset_view();
         return;
     }
-    custom_data.attr("selected", function(d) {
-        var meta = null;
-        if (is_meta_name(d.data.key))
-            meta = name_and_index_from_meta(d.data.key);
-        if (filter.filter_sort()) {
-            if (meta == null)
-                return false;
-            if (meta.index.sort != filter.sort)
-                return false;
-        }
-
-        if (filter.filter_name()) {
-            var name = meta != null ? meta.name : name_from_meta(d.data.key);
-            if (filter.name != name)
-                return false;
-        }
-
-        if (filter.filter_props() != PropertyFilters.None && meta != null) {
-            return !filtered_by_property(filter.filter_props(), meta.index);
-        }
-        return true;
+    if (filter.narrow_context) {
+        prune_with_graph_filter(filter);
+    }
+    graph.drawing.working_data.attr("selected", function(d) {
+        return !meta_name_filtered(d.data.key, filter);
     });
+    // Redraw the nodes.
+    render_nodes(render_canvas.node());
 }
 
 function reset_view() {
-    clicked(custom_data.node().__data__);
+    navigate_to(graph.drawing.working_data.node().__data__);
 }
 
 // See options.js
 function color_updated() {
-    custom_data.attr("fill", function(d) { return color_from_meta(d.data.key); })
+    graph.drawing.working_data.attr("fill", function(d) { return color_from_meta(d.data.key); })
                .attr("gradient-fill", function(d) { return secondary_color_from_meta(d.data.key); });
+    // Redraw the nodes.
+    render_nodes(render_canvas.node());
 }
 
 function transpose_updated() {
     // According to https://github.com/d3/d3-selection/blob/v2.0.0/README.md#selection_data the data bound to the
     // D3 graph is cached by reference (not copied) so all we need to do if a transpose is requested is re-partition
     // the data blob and ask the data element to perform layout over the values.
-    partition.partition();
-    custom_data.transition()
-               .duration(750)
-               .attr("x", function(d) { return node_x(d); })
-               .attr("y", function(d) { return node_y(d); })
-               .attr("width", function(d) { return node_width(d); })
-               .attr("height", function(d) { return node_height(d); });
+    graph.drawing.partition.partition();
+    if (options.graph_animations)
+    {
+        canvas_dirty = true;
+        graph.drawing.working_data.transition()
+                   .duration(750)
+                   .attr("x", function(d) { return node_x(d); })
+                   .attr("y", function(d) { return node_y(d); })
+                   .attr("width", function(d) { return node_width(d); })
+                   .attr("height", function(d) { return node_height(d); })
+                   .end()
+                        .then(() => {
+                            canvas_dirty = false;
+                            // Make sure that we show the nodes in their final position.
+                            render_nodes(render_canvas.node()); } )
+                        .catch(() => {});
+    }
+    else
+    {
+        graph.drawing.working_data
+            .attr("x", function(d) { return node_x(d); })
+            .attr("y", function(d) { return node_y(d); })
+            .attr("width", function(d) { return node_width(d); })
+            .attr("height", function(d) { return node_height(d); });
+        render_nodes(render_canvas.node());
+    }
     reset_view();
+}
+
+function navigate_to_decl_if_possible(index) {
+    // Node names correspond to the stringified handle value.
+    //const found = graph.drawing.working_data.nodes().find(e => e.__data__.data.name == matching_name);
+    const found = graph.drawing.working_data.nodes().find(e => {
+        const name = e.__data__.data.key;
+        if (!is_meta_name(name))
+            return false;
+        const meta = name_and_index_from_meta(name);
+        return meta.index.sort == index.sort && meta.index.index == index.index;
+    });
+    if (found == undefined)
+        return;
+    navigate_to(found.__data__, SkipSelection);
 }

--- a/samples/sgraph-js/ui/ifc-explorer.js
+++ b/samples/sgraph-js/ui/ifc-explorer.js
@@ -1,8 +1,5 @@
 function ifc_explorer_clear_content(content) {
-    // Yes, it is intentional to check for the first and remove the last.
-    while (content.firstChild != null) {
-        content.removeChild(content.lastChild);
-    }
+    remove_all_children(content);
 }
 
 function update_history_sidebar() {
@@ -154,6 +151,8 @@ function ifc_explorer_json_replacer(key, value) {
         return IFCExplorerJSONReplacer.replace_heap_seq(value);
     if (value instanceof BasicSpecifiers)
         return IFCExplorerJSONReplacer.generic_bitset_to_string(BasicSpecifiers, value);
+    if (value instanceof ScopeTraits)
+        return IFCExplorerJSONReplacer.generic_bitset_to_string(ScopeTraits, value);
     if (value instanceof ReachableProperties)
         return IFCExplorerJSONReplacer.generic_bitset_to_string(ReachableProperties, value);
     if (value instanceof FunctionTraits)
@@ -192,11 +191,17 @@ function ifc_explorer_json_replacer(key, value) {
     return value;
 }
 
-function set_ifc_explorer_selected_decl(index, from_history) {
+const SkipNavigation = {};
+
+function set_ifc_explorer_selected_decl(index, from_history, skip_navigation) {
     if (null_index(index)) return;
     ifc_explorer_clear_content(ifc_explorer.decls.content);
     if (!from_history) {
         update_history_with_new_element(DeclIndex, index.sort, index.index);
+    }
+
+    if (!(skip_navigation != undefined && skip_navigation == SkipNavigation)) {
+        navigate_to_decl_if_possible(index);
     }
 
     // Update edits.

--- a/samples/sgraph-js/ui/options.js
+++ b/samples/sgraph-js/ui/options.js
@@ -9,6 +9,7 @@ class Options {
         this.transpose = false;
         this.deselected_opacity = 0.1;
         this.show_fps = false;
+        this.graph_animations = true;
     }
 
     color_for_index(index) {
@@ -281,6 +282,11 @@ function toggle_graph_fps(e, checkbox) {
     // No updated needed.  It is checked in the draw() function.
 }
 
+function toggle_disable_graph_animations(e, checkbox) {
+    // This is a 'is x disabled' so we propagate the inverse.
+    options.graph_animations = !checkbox.checked;
+}
+
 function init_options_dialog() {
     options = new Options();
     populate_decl_color_dropdown();
@@ -295,6 +301,7 @@ function init_options_dialog() {
     reset_class_colors_btn.addEventListener("click", e => reset_class_colors());
     filter_opacity_edit.addEventListener("keyup", event => filter_opacity_keyup(event, filter_opacity_edit));
     graph_fps_toggle.addEventListener("click", event => toggle_graph_fps(event, graph_fps_toggle));
+    graph_animations.addEventListener("click", event => toggle_disable_graph_animations(event, graph_animations));
 
     // Defaults
     // Populate the default color box.


### PR DESCRIPTION
* Add DPI-aware canvas / fix/add `ScopeTraits` to `ScopeDecl`
* Better perf when drawing big graphs (implemented through render target canvas).
* Option for disabling animations.
* Add node hover when mousing over the graph.
* Add ability to prune the graph as you filter.
* Allow ifc explorer to navigate to nodes when loading or clicking decls in the ifc-explorer dialog.
* Fix small bug where we were over-navigating