### PR TITLE
Tidy error reporting types in `ifc-reader`

### DIFF
--- a/include/ifc/reader.hxx
+++ b/include/ifc/reader.hxx
@@ -8,28 +8,19 @@
 #include "ifc/abstract-sgraph.hxx"
 #include "ifc/file.hxx"
 
+namespace ifc::error_condition {
+    // Signal that an inspection for a sort of a given category is unexpected.
+    struct UnexpectedVisitor {
+        std::string_view category;
+        std::string_view sort;
+    };
+}
+
 namespace ifc {
-    // error reporting functions
-
-    [[noreturn]] void not_implemented(std::string_view);
-    [[noreturn]] void not_implemented(std::string_view, int);
-    [[noreturn]] void unexpected(std::string_view);
-    [[noreturn]] void unexpected(std::string_view, int);
-
     template<typename SortTag>
-    [[noreturn]] void unexpected(std::string_view message, SortTag tag)
+    [[noreturn]] std::string unexpected(std::string_view category, SortTag tag)
     {
-        std::string result(message);
-        result.append(sort_name(tag));
-        unexpected(result);
-    }
-
-    template<typename SortTag>
-    [[noreturn]] void not_implemented(std::string_view message, SortTag tag)
-    {
-        std::string result(message);
-        result.append(sort_name(tag));
-        not_implemented(result);
+        throw error_condition::UnexpectedVisitor{category, sort_name(tag)};
     }
 
     class Reader {
@@ -200,7 +191,7 @@ namespace ifc {
             case TypeSort::VendorExtension:
             case TypeSort::Count:
             default:
-                unexpected("visit unexpected type: ", (int)index.sort());
+                unexpected("type", index.sort());
             }
             // clang-format on
         }
@@ -228,7 +219,7 @@ namespace ifc {
             case StmtSort::Decl:    return std::forward<F>(f)(get<symbolic::DeclStmt>(index));
             case StmtSort::Tuple:   return std::forward<F>(f)(get<symbolic::TupleStmt>(index));
             default:
-                unexpected("visit unexpected statement: ", (int)index.sort());
+                unexpected("statement", index.sort());
             }
             // clang-format on
         }
@@ -248,7 +239,7 @@ namespace ifc {
                 case NameSort::SourceFile: return std::forward<F>(f)(get<symbolic::SourceFileName>(index));
                 case NameSort::Guide: return std::forward<F>(f)(get<symbolic::GuideName>(index));
             default:
-                unexpected("visit unexpected name: ", (int)index.sort());
+                unexpected("name", index.sort());
             }
             // clang-format on
         }
@@ -292,7 +283,7 @@ namespace ifc {
             case DeclSort::VendorExtension:
             case DeclSort::Count:
             default:
-                unexpected("visit unexpected decl: ", (int)index.sort());
+                unexpected("decl", index.sort());
             }
             // clang-format on
         }
@@ -363,7 +354,7 @@ namespace ifc {
                 case ExprSort::VendorExtension:
                 case ExprSort::Generic: // C11 generic extension (no IFC structure yet)
                 default:
-                    unexpected("visit unexpected expr: ", (int)index.sort());
+                    unexpected("expr", index.sort());
             }
             // clang-format off
         }

--- a/include/ifc/util.hxx
+++ b/include/ifc/util.hxx
@@ -4,8 +4,8 @@
 #ifndef IFC_UTILS_H
 #define IFC_UTILS_H
 
-#include "ifc/abstract-sgraph.hxx"
 #include <string>
+#include "ifc/abstract-sgraph.hxx"
 
 namespace ifc::util {
     // return a single string for various IFC flags and enums

--- a/src/ifc-printer/main.cxx
+++ b/src/ifc-printer/main.cxx
@@ -1,12 +1,12 @@
 // Copyright Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "ifc/reader.hxx"
-#include "ifc/dom/node.hxx"
-#include "printer.hxx"
 #include <iostream>
 #include <filesystem>
 #include <fstream>
+#include "ifc/reader.hxx"
+#include "ifc/dom/node.hxx"
+#include "printer.hxx"
 
 void translate_exception()
 {
@@ -14,21 +14,22 @@ void translate_exception()
     {
         throw;
     }
-    catch (std::exception& e)
+    catch (const ifc::IfcArchMismatch&)
     {
-        std::cout << "caught: " << e.what() << '\n';
+        std::cerr << "ifc architecture mismatch\n";
     }
-    catch (ifc::IfcArchMismatch&)
+    catch(ifc::error_condition::UnexpectedVisitor& e)
     {
-        std::cout << "ifc architecture mismatch\n";
+        std::cerr << "visit unexpected " << e.category << ": " 
+                  << e.sort << '\n';
     }
     catch (const char* message)
     {
-        std::cout << "caught: " << message;
+        std::cerr << "caught: " << message;
     }
     catch (...)
     {
-        std::cout << "unknown exception caught\n";
+        std::cerr << "unknown exception caught\n";
     }
 }
 

--- a/src/ifc-reader/reader.cxx
+++ b/src/ifc-reader/reader.cxx
@@ -1,22 +1,8 @@
 // Copyright Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "ifc/util.hxx"
 #include "ifc/reader.hxx"
-#include <stdexcept>
-
-class NotYetImplemented : public std::logic_error {
-public:
-    NotYetImplemented(std::string_view what_is_not_implemented)
-      : logic_error("'" + std::string(what_is_not_implemented) + "' is not yet implemented")
-    {}
-};
-
-class Unexpected : public std::logic_error {
-public:
-    Unexpected(std::string_view what_is_not_expected)
-      : logic_error("unexpected: '" + std::string(what_is_not_expected) + "'")
-    {}
-};
 
 namespace ifc {
     constexpr std::string_view analysis_partition_prefix = ".msvc.code-analysis.";
@@ -47,30 +33,6 @@ namespace ifc {
                 summary_by_partition_name(toc, name) = summary;
             }
         }
-    }
-
-    void not_implemented(std::string_view message)
-    {
-        throw NotYetImplemented(message);
-    }
-
-    void not_implemented(std::string_view message, int payload)
-    {
-        std::string result(message);
-        result += std::to_string(payload);
-        not_implemented(result);
-    }
-
-    void unexpected(std::string_view message)
-    {
-        throw Unexpected(message);
-    }
-
-    void unexpected(std::string_view message, int payload)
-    {
-        std::string result(message);
-        result += std::to_string(payload);
-        unexpected(result);
     }
 
 } // namespace ifc


### PR DESCRIPTION
Remove `ifc::not_yet_implemented` and `NotYetImplemented` as unused.
Rework `unexpected`