### PR TITLE
Fix typos

### DIFF
--- a/include/ifc/abstract-sgraph.hxx
+++ b/include/ifc/abstract-sgraph.hxx
@@ -554,7 +554,7 @@ namespace ifc {
                                    // FIXME: See bug https://github.com/microsoft/ifc-spec/issues/128
         TemplateId,                // A template-id expression.
         UnqualifiedId,             // An unqualified-id + some other stuff like 'template' and/or 'typename'.
-                                   // FXIME: See bug https://github.com/microsoft/ifc-spec/issues/128
+                                   // FIXME: See bug https://github.com/microsoft/ifc-spec/issues/128
         SimpleIdentifier,          // Just an identifier: nothing else.
                                    // FIXME: See bug https://github.com/microsoft/ifc-spec/issues/128
         Pointer,                   // A '*' when it appears as part of a qualified-name.
@@ -660,7 +660,7 @@ namespace ifc {
         Count,
     };
 
-    // Type of abstract references to pragama structures
+    // Type of abstract references to pragma structures
     struct PragmaIndex : index_like::Over<PragmaSort> {
         using Over<PragmaSort>::Over;
     };
@@ -1087,7 +1087,7 @@ namespace ifc {
         // Note: All structures defined in this namespaces are to be removed when `SyntaxSort` is removed.
         // See bug https://github.com/microsoft/ifc-spec/issues/127
         namespace syntax {
-            // DecltypeSpecifer is 'decltype(expression)'. DecltypeAutoSpecifier is 'decltype(auto)'. See below.
+            // DecltypeSpecifier is 'decltype(expression)'. DecltypeAutoSpecifier is 'decltype(auto)'. See below.
             struct DecltypeSpecifier : Tag<SyntaxSort::DecltypeSpecifier> {
                 ExprIndex expression{};            // The expression (for 'auto', see DecltypeAutoSpecifier)
                 SourceLocation decltype_keyword{}; // The source location of the 'decltype'
@@ -1842,7 +1842,7 @@ namespace ifc {
             enum class FoldKind : uint32_t { // FIXME: this should be uint8_t
                 Unknown,
                 LeftFold,  // Some form of left fold expression
-                RightFold, // Some form of righr fold expression
+                RightFold, // Some form of right fold expression
             };
 
             struct UnaryFoldExpression : Tag<SyntaxSort::UnaryFoldExpression> {
@@ -2327,7 +2327,7 @@ namespace ifc {
         // A constructor declaration.
         struct InheritedConstructorDecl : Tag<DeclSort::InheritedConstructor> {
             Identity<TextOffset> identity{}; // What identifies this constructor
-            TypeIndex type{};                // Type of this contructor declaration.
+            TypeIndex type{};                // Type of this constructor declaration.
             DeclIndex home_scope{};          // Enclosing scope of this declaration.
             ChartIndex chart{};              // Function parameter list.
             FunctionTraits traits{};         // Function traits
@@ -2349,7 +2349,7 @@ namespace ifc {
         };
 
         // A deduction guide for class template.
-        // Note: If the deduction guide was paramterized by a template, then this would be
+        // Note: If the deduction guide was parameterized by a template, then this would be
         // the corresponding parameterized decl.  The template declaration itself has no name.
         struct DeductionGuideDecl : Tag<DeclSort::DeductionGuide> {
             Identity<NameIndex> identity{}; // associated primary template and location of declaration
@@ -2679,7 +2679,7 @@ namespace ifc {
         };
 
         struct DynamicDispatchExpr : LocationAndType<ExprSort::DynamicDispatch> {
-            ExprIndex postfix_expr{}; // The posfix expression on a call to a virtual function.
+            ExprIndex postfix_expr{}; // The postfix expression on a call to a virtual function.
         };
 
         struct VirtualFunctionConversionExpr : LocationAndType<ExprSort::VirtualFunctionConversion> {
@@ -3305,7 +3305,7 @@ namespace ifc {
         // two static_cast; the other uses no casts but field names.  The whole point
         // of having this facility is separate field names from the abstract structure,
         // so that fields order does not matter.  The two static_casts would be
-        // just being overly pedantic.  This construct is well understood and welldefined.
+        // just being overly pedantic.  This construct is well understood and well-defined.
         // Bug: lot of comments for a one-liner.
         auto begin()
         {

--- a/include/ifc/file.hxx
+++ b/include/ifc/file.hxx
@@ -157,7 +157,7 @@ namespace ifc {
 
     // Module interface header
     struct Header {
-        SHA256Hash content_hash;       // For verifying the intregity of the .ifc contents below.
+        SHA256Hash content_hash;       // For verifying the integrity of the .ifc contents below.
         FormatVersion version;         // Version of the IFC file format
         Abi abi;                       // Abi tag.
         Architecture arch;             // Target machine architecture tag.
@@ -170,7 +170,7 @@ namespace ifc {
         ByteOffset toc;                // Offset to the table of contents.
         Cardinality partition_count;   // Number of partitions, including the string table partition.
         bool internal_partition; // Set to true if this TU does not contribute to a module unit external interface.
-                                 // FIXME: Gaby, find a better representataion for this.
+                                 // FIXME: Gaby, find a better representation for this.
     };
 
     // Partition info in the ToC of a module interface.

--- a/include/ifc/index-utils.hxx
+++ b/include/ifc/index-utils.hxx
@@ -149,13 +149,13 @@ namespace index_like {
         }
     } // namespace operators
 
-    // For an index-like type over a sort S, this constant holds the number of bitsf
+    // For an index-like type over a sort S, this constant holds the number of bits
     // necessary to represent the tags from S.
     // Note: There is no satisfactory concept expression of 'sort' at this point.
     //       Just defining that concept as a check for 'Count' enumerator is not
     //       desirable as that does not capture the notion of sort -- it would only
     //       inappropriately elevate an implementation detail/trick to specification.
-    // Note: suffices to substract 1 from 'Count' since it is 1 greater than the actual largest value.
+    // Note: suffices to subtract 1 from 'Count' since it is 1 greater than the actual largest value.
     template<typename S>
     constexpr auto tag_precision =
         ifc::to_underlying(S::Count) == 0 ? 0u : ifc::bit_length(ifc::to_underlying(S::Count) - 1u);

--- a/include/ifc/operators.hxx
+++ b/include/ifc/operators.hxx
@@ -48,7 +48,7 @@ namespace ifc {
     // clang-format off
     enum class MonadicOperator : uint16_t {
         Unknown,
-        Plus,                                               // +x                   -- unethtical on non-literals, operator at source level
+        Plus,                                               // +x                   -- unethical on non-literals, operator at source level
         Negate,                                             // -x
         Deref,                                              // *p
         Address,                                            // &x
@@ -215,7 +215,7 @@ namespace ifc {
         Select,                             // x :: y
 
         Msvc = 0x0400,
-        MsvcTryCast,                        // WinTR try cast
+        MsvcTryCast,                        // WinRT try cast
         MsvcCurry,                          // MSVC bound member function extension
         MsvcVirtualCurry,                   // same as MsvcCurry, except the binding requires dynamic dispatch
         MsvcAlign,                          //                      -- alignment adjustment
@@ -236,7 +236,7 @@ namespace ifc {
         MsvcBuiltinIsPointerInterconvertibleWithClass,      // __builtin_is_pointer_interconvertible_with_class(U, V)
         MsvcBuiltinIsCorrespondingMember,   // __builtin_is_corresponding_member(x, y)
         MsvcIntrinsic,                      //                      -- abstract machine, misc intrinsic with no regular function declaration
-        MsvcSaturatedArithmetic,            // An MSVC intrinsic for an abstract machine saturated arithemtic operation.
+        MsvcSaturatedArithmetic,            // An MSVC intrinsic for an abstract machine saturated arithmetic operation.
         MsvcBuiltinAllocationAnnotation,    // An MSVC intrinsic used to propagate debugging information to the runtime.  __allocation_annotation(x, T)
 
         Last

--- a/include/ifc/source-word.hxx
+++ b/include/ifc/source-word.hxx
@@ -23,7 +23,7 @@ namespace ifc {
 
     // C1xx internally stores the initializer (in the IPR sense) of templated definitions
     // as a sequence of its internal notion of tokens (here abstracted as 'words').  As a
-    // temporary measure, those c1xx-tokens are abtracted into words of various sorts,
+    // temporary measure, those c1xx-tokens are abstracted into words of various sorts,
     // shielded from the token-du-jour update vagaries.  These temporary measures will be
     // removed as c1xx gains more a principled internal representation.
     namespace source {
@@ -256,7 +256,7 @@ namespace ifc {
             Typeid,          // "typeid"
             Typename,        // "typename"
             Union,           // "union"
-            Unsigned,        // "unaigned"
+            Unsigned,        // "unsigned"
             Using,           // "using"
             Virtual,         // "virtual"
             Void,            // "void"
@@ -299,7 +299,7 @@ namespace ifc {
             MsvcSingleInheritance,   // "__single_inheritance"
             MsvcSptr,                // "__sptr"
             MsvcStdcall,             // "__stdcall"
-            MsvcSuper,               // "__surper"
+            MsvcSuper,               // "__super"
             MsvcThiscall,            // "__thiscall"
             MsvcSehTry,              // "__try"
             MsvcUptr,                // "__ptr"
@@ -317,7 +317,7 @@ namespace ifc {
             MsvcIsEmpty,                                   // "__is_empty"
             MsvcHasTrivialConstructor,                     // "__has_trivial_constructor"
             MsvcIsTriviallyConstructible,                  // "__is_trivially_constructible"
-            MsvcIsTriaviallyCopyConstructible,             // "__is_trivially_copy_constructible"
+            MsvcIsTriviallyCopyConstructible,              // "__is_trivially_copy_constructible"
             MsvcIsTriviallyCopyAssignable,                 // "__is_trivially_copy_assignable"
             MsvcIsTriviallyDestructible,                   // "__is_trivially_destructible"
             MsvcHasVirtualDestructor,                      // "__has_virtual_destructor"

--- a/samples/sgraph-js/sgraph/operators.js
+++ b/samples/sgraph-js/sgraph/operators.js
@@ -69,7 +69,7 @@ class MonadicOperator {
         MsvcIsEnum:                         0x0406, // __is_enum(T)
         MsvcIsPolymorphic:                  0x0407, // __is_polymorphic(T)
         MsvcIsEmpty:                        0x0408, // __is_empty(T)
-        MsvcIsTriaviallyCopyConstructible:  0x0409, // __is_trivially_copy_constructible(T)
+        MsvcIsTriviallyCopyConstructible:   0x0409, // __is_trivially_copy_constructible(T)
         MsvcIsTriviallyCopyAssignable:      0x040A, // __is_trivially_copy_assignable(T)
         MsvcIsTriviallyDestructible:        0x040B, // __is_trivially_destructible(T)
         MsvcHasVirtualDestructor:           0x040C, // __has_virtual_destructor(T)
@@ -192,7 +192,7 @@ class DyadicOperator {
         Select:             64, // x :: y
 
         Msvc:                                          0x0400,
-        MsvcTryCast:                                   0x0401, // WinTR try cast
+        MsvcTryCast:                                   0x0401, // WinRT try cast
         MsvcCurry:                                     0x0402, // MSVC bound member function extension
         MsvcVirtualCurry:                              0x0403, // same as MsvcCurry, except the binding requires dynamic dispatch
         MsvcAlign:                                     0x0404, //                      -- alignment adjustment
@@ -213,7 +213,7 @@ class DyadicOperator {
         MsvcBuiltinIsPointerInterconvertibleWithClass: 0x0413, // __builtin_is_pointer_interconvertible_with_class(U, V)
         MsvcBuiltinIsCorrespondingMember:              0x0414, // __builtin_is_corresponding_member(x, y)
         MsvcIntrinsic:                                 0x0415, //                      -- abstract machine, misc intrinsic with no regular function declaration
-        MsvcSaturatedArithmetic:                       0x0416, // An MSVC intrinsic for an abstract machine saturated arithemtic operation.
+        MsvcSaturatedArithmetic:                       0x0416, // An MSVC intrinsic for an abstract machine saturated arithmetic operation.
         MsvcBuiltinAllocationAnnotation:               0x0417, // An MSVC intrinsic used to propagate debugging information to the runtime.  __allocation_annotation(x, T)
 
         Count:                                         0x0417

--- a/samples/sgraph-js/sgraph/sgraph.js
+++ b/samples/sgraph-js/sgraph/sgraph.js
@@ -138,7 +138,7 @@ class ExprIndex {
                                        // FIXME: See bug https://github.com/microsoft/ifc-spec/issues/128
         TemplateId:                7,  // A template-id expression.
         UnqualifiedId:             8,  // An unqualified-id + some other stuff like 'template' and/or 'typename'.
-                                       // FXIME: See bug https://github.com/microsoft/ifc-spec/issues/128
+                                       // FIXME: See bug https://github.com/microsoft/ifc-spec/issues/128
         SimpleIdentifier:          9,  // Just an identifier: nothing else.
                                        // FIXME: See bug https://github.com/microsoft/ifc-spec/issues/128
         Pointer:                   10, // A '*' when it appears as part of a qualified-name.


### PR DESCRIPTION
Most of these typos were in comments, but "Triavially" occurred in identifiers.

