### PR TITLE
Focus on InvalidPartitionName's string memory bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /linux-build/
-
+/.vs/
+/out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ set(CMAKE_CXX_STANDARD 20)
 
 add_definitions(-DVERSP_RELEASE=$<CONFIG:Release> -DVERSP_DEBUG=$<CONFIG:Debug> -DNOMINMAX)
 
+# Comment out this line to use std::string instead of std::string_view in InvalidPartitionName
+# add_compile_definitions(FIX_MEMORY_ACCESS_BUG)
+
 include_directories (include)
 
 add_subdirectory (src)

--- a/include/ifc/abstract-sgraph.hxx
+++ b/include/ifc/abstract-sgraph.hxx
@@ -3518,7 +3518,11 @@ namespace ifc {
 
     // -- exception type in case of an invalid partition name
     struct InvalidPartitionName {
+#ifdef FIX_MEMORY_ACCESS_BUG
+        std::string name;
+#else
         std::string_view name;
+#endif
     };
 
     // Retrieve a partition summary based on the partition's name.

--- a/src/ifc-printer/CMakeLists.txt
+++ b/src/ifc-printer/CMakeLists.txt
@@ -14,3 +14,9 @@ target_link_libraries(ifc-printer
 )
 
 target_link_libraries(ifc-printer PRIVATE GSL)
+
+add_custom_command(
+        TARGET ifc-printer POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_CURRENT_SOURCE_DIR}/file.cxx.ifc
+                ${CMAKE_CURRENT_BINARY_DIR}/file.cxx.ifc)

--- a/src/ifc-printer/main.cxx
+++ b/src/ifc-printer/main.cxx
@@ -18,6 +18,10 @@ void translate_exception()
     {
         std::cerr << "ifc architecture mismatch\n";
     }
+    catch (ifc::InvalidPartitionName& e)
+    {
+        std::cout << "ifc invalid partition name: '" << e.name << "'\n";
+    }
     catch(ifc::error_condition::UnexpectedVisitor& e)
     {
         std::cerr << "visit unexpected " << e.category << ": " 

--- a/src/sgraph.cxx
+++ b/src/sgraph.cxx
@@ -545,7 +545,11 @@ namespace ifc {
         {
             auto p = table.find(name);
             if (p == table.end())
+#ifdef FIX_MEMORY_ACCESS_BUG
+                throw InvalidPartitionName{std::string{name}};
+#else
                 throw InvalidPartitionName{name};
+#endif
             return p->sort;
         }
 


### PR DESCRIPTION
Hi
I closed inadvertently my previous PR https://github.com/microsoft/ifc/pull/30, probably because I force-pushed my related branch.
So, I am creating another PR to focus specifically on the memory/life-time issue when catching _InvalidPartitionName_ in _translate_exception_ and accessing the member _name_.
I hope this can help @cdacamar reproduce/analyze the issue.
(I have put my sample file and added some temporary cmake-stuff to test it easily)