### PR TITLE
Up CMake minimum reversion and C++ version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
   target_sources(ifc-reader PRIVATE src/sha256.cxx)
 endif()
 target_link_libraries(ifc-reader PUBLIC Microsoft.GSL::GSL)
-target_compile_features(ifc-reader PUBLIC cxx_std_20)
+target_compile_features(ifc-reader PUBLIC cxx_std_23)
 target_include_directories(ifc-reader PUBLIC "\$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 
 add_library(
@@ -54,7 +54,7 @@ add_library(
 add_library(Microsoft.IFC::DOM ALIAS ifc-dom)
 set_property(TARGET ifc-dom PROPERTY EXPORT_NAME DOM)
 target_link_libraries(ifc-dom PUBLIC ifc-reader)
-target_compile_features(ifc-dom PUBLIC cxx_std_20)
+target_compile_features(ifc-dom PUBLIC cxx_std_23)
 target_include_directories(ifc-reader PUBLIC "\$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 
 add_library(SDK INTERFACE)
@@ -70,7 +70,7 @@ if(BUILD_PRINTER)
       src/assert.cxx
   )
   target_link_libraries(ifc-printer PRIVATE ifc-dom ifc-reader)
-  target_compile_features(ifc-printer PRIVATE cxx_std_20)
+  target_compile_features(ifc-printer PRIVATE cxx_std_23)
 endif()
 
 if(NOT CMAKE_SKIP_INSTALL_RULES)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 2,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 14,
+    "minor": 27,
     "patch": 0
   },
   "configurePresets": [
@@ -49,7 +49,7 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_CXX_EXTENSIONS": "OFF",
-        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CXX_STANDARD": "23",
         "CMAKE_CXX_STANDARD_REQUIRED": "ON"
       }
     },
@@ -74,7 +74,7 @@
       "description": "Note that all the flags after /W4 are required for MSVC to conform to the language standard",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /permissive- /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:lambda /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc",
+        "CMAKE_CXX_FLAGS": "/sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc",
         "CMAKE_EXE_LINKER_FLAGS": "/machine:x64 /guard:cf"
       }
     },


### PR DESCRIPTION
Require CMake 3.27, and C++23 for development.