### PR TITLE
Set CMake minimum version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20)
 
 # Corresponds to https://github.com/microsoft/ifc-spec
 set(ifc_spec_version 0.43)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 2,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 27,
+    "minor": 20,
     "patch": 0
   },
   "configurePresets": [

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20)
 
 project(ifc-sdk-tests CXX)
 


### PR DESCRIPTION
This is the first version that started supporting the cxx_std_23 compile feature.

https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html

Fixes https://github.com/microsoft/ifc/pull/47#discussion_r1365911762