### PR TITLE
Revert "add BarrenDecl to reader dispatch list"

### DIFF
--- a/include/ifc/reader.hxx
+++ b/include/ifc/reader.hxx
@@ -278,8 +278,8 @@ namespace ifc {
             case DeclSort::Property:     return std::forward<F>(f)(index, get<symbolic::PropertyDecl>(index));
             case DeclSort::OutputSegment: return std::forward<F>(f)(index, get<symbolic::SegmentDecl>(index));
             case DeclSort::SyntaxTree:   return std::forward<F>(f)(index, get<symbolic::SyntacticDecl>(index));
-            case DeclSort::Barren:       return std::forward<F>(f)(index, get<symbolic::BarrenDecl>(index));
 
+            case DeclSort::Barren:         // IFC has no corresponding structure as of 05/12/2022
             case DeclSort::VendorExtension:
             case DeclSort::Count:
             default:


### PR DESCRIPTION
This reverts commit f064b7ca3c8997ee1fa91a5939abdbfecf1033f7.

This commit was mistakenly pushed.