### PR TITLE
Update CMake minimum version everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.26)
 
 # Corresponds to https://github.com/microsoft/ifc-spec
 set(ifc_spec_version 0.43)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.27)
 
 # Corresponds to https://github.com/microsoft/ifc-spec
 set(ifc_spec_version 0.43)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 2,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 27,
+    "minor": 26,
     "patch": 0
   },
   "configurePresets": [

--- a/include/ifc/reader.hxx
+++ b/include/ifc/reader.hxx
@@ -278,8 +278,8 @@ namespace ifc {
             case DeclSort::Property:     return std::forward<F>(f)(index, get<symbolic::PropertyDecl>(index));
             case DeclSort::OutputSegment: return std::forward<F>(f)(index, get<symbolic::SegmentDecl>(index));
             case DeclSort::SyntaxTree:   return std::forward<F>(f)(index, get<symbolic::SyntacticDecl>(index));
-            case DeclSort::Barren:       return std::forward<F>(f)(index, get<symbolic::BarrenDecl>(index));
 
+            case DeclSort::Barren:       // IFC has no corresponding structure as of 05/12/2022
             case DeclSort::VendorExtension:
             case DeclSort::Count:
             default:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.27)
 
 project(ifc-sdk-tests CXX)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.26)
 
 project(ifc-sdk-tests CXX)
 


### PR DESCRIPTION
In #47 , I failed to update the minimum required version of CMake everywhere that needs updating.  Hopefully, this PR fixes those places.

Note: Ideally, we should have only one place to update.