### PR TITLE
Try fixing exceptions stuff accordingly to comments in #30 and #36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vs/
 /build/
 /prefix/
 /linux-build/

--- a/include/ifc/abstract-sgraph.hxx
+++ b/include/ifc/abstract-sgraph.hxx
@@ -3544,7 +3544,18 @@ namespace ifc {
 
     // -- exception type in case of an invalid partition name
     struct InvalidPartitionName {
-        std::string_view name;
+        static constexpr unsigned NAME_BUFFER_SIZE = 64;
+
+        char name[NAME_BUFFER_SIZE]                = "";
+
+        static InvalidPartitionName make(std::string_view name) noexcept
+        {
+            InvalidPartitionName e{};
+            name = name.substr(0, NAME_BUFFER_SIZE - 1);
+            strncpy_s(e.name, name.data(), name.length());
+            e.name[name.length()] = 0;
+            return e;
+        }
     };
 
     // Retrieve a partition summary based on the partition's name.

--- a/src/ifc-printer/main.cxx
+++ b/src/ifc-printer/main.cxx
@@ -18,14 +18,18 @@ void translate_exception()
     {
         std::cerr << "ifc architecture mismatch\n";
     }
-    catch(ifc::error_condition::UnexpectedVisitor& e)
+    catch (const ifc::InvalidPartitionName& e)
+    {
+        std::cerr << "invalid partition name: " << e.name << '\n';
+    }
+    catch (ifc::error_condition::UnexpectedVisitor& e)
     {
         std::cerr << "visit unexpected " << e.category << ": " 
                   << e.sort << '\n';
     }
-    catch (const char* message)
+    catch (const std::exception& e)
     {
-        std::cerr << "caught: " << message;
+        std::cerr << "caught std exception: " << e.what();
     }
     catch (...)
     {

--- a/src/ifc-reader/reader.cxx
+++ b/src/ifc-reader/reader.cxx
@@ -3,14 +3,14 @@
 
 #include "ifc/util.hxx"
 #include "ifc/reader.hxx"
+#include <cassert>
 
 namespace ifc {
     constexpr std::string_view analysis_partition_prefix = ".msvc.code-analysis.";
 
     Reader::Reader(const ifc::InputIfc& ifc_) : ifc(ifc_)
     {
-        if (not ifc.header())
-            throw "file not found";
+        assert(ifc.header());
         read_table_of_contents();
     }
 

--- a/src/sgraph.cxx
+++ b/src/sgraph.cxx
@@ -546,7 +546,7 @@ namespace ifc {
         {
             auto p = table.find(name);
             if (p == table.end())
-                throw InvalidPartitionName{name};
+                throw InvalidPartitionName::make(name);
             return p->sort;
         }
 


### PR DESCRIPTION
Try a minimal fix:
- In `struct InvalidPartitionName`, replace member `std::string_view name` by `char[NAME_BUFFER_SIZE] name` and use a class-static `make` function to initialize the buffer
- In `Reader::Reader`, replace `if (not ifc.header()) throw "file not found";` by `assert(ifc.hader());`
- In `translate_exception()`, catch the exceptions of type `InvalidPartitionName` and `std::exception`