### PR TITLE
Add a simple `ifc` tool driver command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ include(CMakeDependentOption)
 
 find_package(Microsoft.GSL REQUIRED)
 
+# Those pesky min/max macros.
+if(WIN32)
+  add_compile_definitions(NOMINMAX)
+endif()
+
 # The `reader` component.
 add_library(
     ifc-reader STATIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include(CMakeDependentOption)
 
 find_package(Microsoft.GSL REQUIRED)
 
+# The `reader` component.
 add_library(
     ifc-reader STATIC
     src/file.cxx
@@ -39,6 +40,7 @@ target_link_libraries(ifc-reader PUBLIC Microsoft.GSL::GSL)
 target_compile_features(ifc-reader PUBLIC cxx_std_23)
 target_include_directories(ifc-reader PUBLIC "\$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 
+# The `dom` component.
 add_library(
     ifc-dom STATIC
     src/ifc-dom/charts.cxx
@@ -55,8 +57,20 @@ add_library(Microsoft.IFC::DOM ALIAS ifc-dom)
 set_property(TARGET ifc-dom PROPERTY EXPORT_NAME DOM)
 target_link_libraries(ifc-dom PUBLIC ifc-reader)
 target_compile_features(ifc-dom PUBLIC cxx_std_23)
-target_include_directories(ifc-reader PUBLIC "\$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_include_directories(ifc-dom PUBLIC "\$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 
+# The `ifc` tool executable.
+add_executable(
+  ifc
+  src/tools/ifc.cxx
+)
+add_executable(Microsoft.IFC::Tool ALIAS ifc)
+set_property(TARGET ifc PROPERTY EXPORT_NAME Tool)
+target_compile_features(ifc PUBLIC cxx_std_23)
+target_link_libraries(ifc ifc-reader)
+target_include_directories(ifc PUBLIC "\$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+
+# The IFC SDK comprises the `reader`, the `dom`, and the tool.
 add_library(SDK INTERFACE)
 add_library(Microsoft.IFC::SDK ALIAS SDK)
 target_link_libraries(SDK INTERFACE ifc-reader ifc-dom)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -74,7 +74,7 @@
       "description": "Note that all the flags after /W4 are required for MSVC to conform to the language standard",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc",
+        "CMAKE_CXX_FLAGS": "/DWIN32 /sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc",
         "CMAKE_EXE_LINKER_FLAGS": "/machine:x64 /guard:cf"
       }
     },

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -20,6 +20,11 @@ install(
 )
 
 install(
+    TARGETS ifc
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)
+
+install(
     TARGETS ifc-dom ifc-reader SDK
     EXPORT Microsoft.IFCTargets
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"

--- a/include/ifc/tooling.hxx
+++ b/include/ifc/tooling.hxx
@@ -1,0 +1,40 @@
+// Copyright Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IFC_TOOLING_INCLUDED
+#define IFC_TOOLING_INCLUDED
+
+#include <string_view>
+#include <string>
+#include <filesystem>
+
+namespace ifc {
+    // Filesystem component.  Forward to standard facilities.
+    namespace fs = std::filesystem;
+}
+
+// Basic datatypes for tooling extension.
+namespace ifc::tool {
+    // -- Native pathname character type.
+    using NativeChar = fs::path::value_type;
+
+    // -- A read-only view type over native strings.
+    using StringView = std::basic_string_view<NativeChar>;
+
+    // -- A container type for native string.
+    using String = std::basic_string<NativeChar>;
+
+    // -- Type of an IFC subcommand name
+    using Name = StringView;
+
+    // -- A container type for the arguments to a subcommand.
+    using Arguments = std::vector<StringView>;
+
+    // -- Base class for an ifc subcommand extension.
+    struct Extension {
+        virtual Name name() const = 0;
+        virtual int run_with(const Arguments&) const = 0;
+    };
+}
+
+#endif

--- a/src/tools/ifc.cxx
+++ b/src/tools/ifc.cxx
@@ -1,0 +1,118 @@
+// Copyright Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <stdlib.h>
+#include <vector>
+#include <span>
+#include <algorithm>
+#include <iostream>
+
+#ifdef WIN32
+#   include <windows.h>
+#endif
+
+#include "ifc/tooling.hxx"
+
+#ifdef WIN32
+#   define STR(S) L ## S
+#   define IFC_MAIN wmain
+#   define IFC_ERR std::wcerr
+#else 
+#   define STR(S) S
+#   define IFC_MAIN main
+#   define IFC_ERR std::cerr
+#endif
+
+namespace {
+    using ProgramName = ifc::tool::StringView;
+
+    void print_usage(const ProgramName& prog)
+    {
+        IFC_ERR << prog << STR(" usage:\n\t")
+            << prog << STR(" <cmd> [options] <ifc-files>\n");
+    }
+
+    // -- Subcommand printing the Spec version from an IFC file.
+    struct VersionCommand : ifc::tool::Extension {
+        ifc::tool::Name name() const final { return STR("version"); }
+        int run_with(const ifc::tool::Arguments&) const final
+        {
+            return 0;
+        }
+    };
+
+    constexpr VersionCommand version_cmd { };
+
+    // -- List of all builtin subcommands, sorted by their name.
+    constexpr const ifc::tool::Extension* builtin_extensions[] {
+        &version_cmd,
+    };
+    static_assert(std::ranges::is_sorted(builtin_extensions, { }, &ifc::tool::Extension::name));
+
+    const ifc::tool::Extension* builtin_operation(const ifc::tool::Name& cmd)
+    {
+        auto ext = std::ranges::lower_bound(builtin_extensions, cmd, { }, &ifc::tool::Extension::name);
+        if (ext < std::end(builtin_extensions) and (*ext)->name() == cmd)
+            return *ext;
+        return nullptr;
+    }
+
+    // Enclose the argument in double quotes.
+    ifc::tool::String quote(const ifc::tool::StringView& s)
+    {
+        static constexpr auto kwote_str = STR("\"");
+        ifc::tool::String r = kwote_str;
+        r += s;
+        r += kwote_str;
+        return r;
+    }
+}
+
+
+int IFC_MAIN(int argc, ifc::tool::NativeChar* argv[])
+{
+    // The `ifc` tool itself does not accept any option.
+    int idx = 1;
+    while (idx < argc) {
+        ifc::tool::StringView s { argv[idx] };
+        if (not s.starts_with(STR("-")))
+            break;
+        ++idx;
+    }
+
+    if (argc < 2 or idx > 1 or idx >= argc) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    // The subcommand name is next, after possibly invalid options.
+    // It shall not contain any path separator character.
+    ifc::tool::Name cmd { argv[idx] };
+    if (cmd.contains(STR("/")[0]) or cmd.contains(STR("\\")[0])) {
+        IFC_ERR << STR("ifc subcommand cannot contain pathname separator") << std::endl;
+        return 1;
+    }
+
+    ifc::tool::Arguments args { argv + idx + 1, argv + argc };
+
+    if (auto op = builtin_operation(cmd))
+        return op->run_with(args);
+
+    ifc::tool::String tool = STR("ifc-");
+    tool += cmd;
+    ifc::tool::String command = quote(tool);
+    for (auto& arg : args) {
+        command += STR(" ");
+        command += quote(arg);
+    }
+
+#ifdef WIN32
+    auto status = _wsystem(command.c_str());
+#else
+    auto status = system(command.c_str());
+#endif
+    if (status != 0)
+        IFC_ERR << STR("ifc: no subcommand named '") << cmd << STR("'") << std::endl;
+    return status;
+}
+

--- a/src/tools/ifc.cxx
+++ b/src/tools/ifc.cxx
@@ -18,7 +18,7 @@
 #ifdef WIN32
 #   define STR(S) L ## S
 #   define IFC_MAIN wmain
-#   define IFC_OUT std::cout
+#   define IFC_OUT std::wcout
 #   define IFC_ERR std::wcerr
 #else 
 #   define STR(S) S
@@ -41,7 +41,7 @@ namespace {
     {
         auto name = prog.stem();
         IFC_ERR << name << STR(" usage:\n\t")
-            << name.string() << STR(" <cmd> [options] <ifc-files>\n");
+            << name.native() << STR(" <cmd> [options] <ifc-files>\n");
     }
 
     // -- Check that the input file has a valid IFC file header signature.


### PR DESCRIPTION
This PR adds a simple interface tool `ifc` to drive extension commands that operate on IFC files.  The typical usage is:
```
$ ifc <subcmd> opt1 opt2... file1 file2...
``` 
where _subcmd_ is an IFC tool subcommand.  The subcommand can be a built-in `ifc` subcommand, or an external extension subcommand (any executable found in your `PATH` environment variable).  The external subcommand must be an executable named `ifc-`_subcmd_.  Only the `version` subcommand is supported in this PR.  More may be added in the future.