### PR TITLE
Add a return code to main

### DIFF
--- a/src/ifc-printer/main.cxx
+++ b/src/ifc-printer/main.cxx
@@ -135,7 +135,6 @@ void process_ifc(const std::string& name, PrintOptions options)
 int main(int argc, char** argv)
 {
     Arguments arguments = process_args(argc, argv);
-    int return_code = EXIT_SUCCESS;
 
     try
     {
@@ -145,8 +144,8 @@ int main(int argc, char** argv)
     catch (...)
     {
         translate_exception();
-        return_code = EXIT_FAILURE;
+        return EXIT_FAILURE;
     }
 
-    return return_code;
+    return EXIT_SUCCESS;
 }

--- a/src/ifc-printer/main.cxx
+++ b/src/ifc-printer/main.cxx
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <filesystem>
 #include <fstream>
+#include <cstdlib>
 #include "ifc/reader.hxx"
 #include "ifc/dom/node.hxx"
 #include "printer.hxx"
@@ -134,6 +135,7 @@ void process_ifc(const std::string& name, PrintOptions options)
 int main(int argc, char** argv)
 {
     Arguments arguments = process_args(argc, argv);
+    int return_code = EXIT_SUCCESS;
 
     try
     {
@@ -143,5 +145,8 @@ int main(int argc, char** argv)
     catch (...)
     {
         translate_exception();
+        return_code = EXIT_FAILURE;
     }
+
+    return return_code;
 }


### PR DESCRIPTION
This PR adds a return code to `ifc-printer` such that you get a non-zero return code if there's an exception.

Signed-off-by: Andrew V. Teylu <andrew.teylu@vector.com>