### PR TITLE
Fix tests / add visualizer behavior

### DIFF
--- a/samples/sgraph-js/globals.js
+++ b/samples/sgraph-js/globals.js
@@ -61,6 +61,9 @@ const ifc_explorer = {
         load: document.getElementById('ifc-explorer-content-exprs-load'),
         validation_tooltip: document.getElementById('ifc-explorer-content-exprs-load-validation')
     },
+    files: {
+        content: document.getElementById('ifc-explorer-content-ifc-files')
+    },
     toc: {
         content: document.getElementById('ifc-explorer-content-toc')
     },

--- a/samples/sgraph-js/index.html
+++ b/samples/sgraph-js/index.html
@@ -198,6 +198,9 @@
                                         <a class="nav-link" id="ifc-explorer-exprs-tab" data-toggle="tab" href="#ifc-explorer-exprs" role="tab" aria-controls="ifc-explorer-exprs" aria-selected="false">Exprs</a>
                                     </li>
                                     <li class="nav-item">
+                                        <a class="nav-link" id="ifc-explorer-ifc-files-tab" data-toggle="tab" href="#ifc-explorer-ifc-files" role="tab" aria-controls="ifc-explorer-ifc-files" aria-selected="false">Referenced Files</a>
+                                    </li>
+                                    <li class="nav-item">
                                         <a class="nav-link" id="ifc-explorer-ifc-header-tab" data-toggle="tab" href="#ifc-explorer-ifc-header" role="tab" aria-controls="ifc-explorer-ifc-header" aria-selected="false">IFC Header</a>
                                     </li>
                                     <li class="nav-item">
@@ -240,6 +243,9 @@
                                             <span id="ifc-explorer-content-exprs-load-validation" class="invalid-tooltip">placeholder</span>
                                         </div>
                                         <div class="modal-body" id="ifc-explorer-content-exprs"></div>
+                                    </div>
+                                    <div class="tab-pane fade" id="ifc-explorer-ifc-files" role="tabpanel" aria-labelledby="ifc-explorer-ifc-files-tab">
+                                        <div class="modal-body" id="ifc-explorer-content-ifc-files"></div>
                                     </div>
                                     <div class="tab-pane fade" id="ifc-explorer-ifc-header" role="tabpanel" aria-labelledby="ifc-explorer-ifc-header-tab">
                                         <div class="modal-body" id="ifc-explorer-content-ifc-header"></div>

--- a/samples/sgraph-js/ui/ifc-explorer.js
+++ b/samples/sgraph-js/ui/ifc-explorer.js
@@ -425,6 +425,23 @@ function ifc_explorer_init_exprs() {
     ifc_explorer.exprs.load.addEventListener("click", e => ifc_explorer_load_expr(e));
 }
 
+function ifc_explorer_init_files() {
+    const sourcefile_partition = sgraph.resolver.toc.partition(SourceFileName);
+    if (sourcefile_partition == null) {
+        return;
+    }
+    const count = sourcefile_partition.cardinality;
+    var files = new Array();
+    for (var i = 0; i < count; ++i) {
+        const source_file = sgraph.resolver.read(SourceFileName, i);
+        files.push(sgraph.resolver.string_table.get(source_file.name));
+    }
+    const json_str = JSON.stringify(files, null, 2);
+    const container = document.createElement("pre");
+    container.innerHTML = json_str;
+    ifc_explorer.files.content.appendChild(container);
+}
+
 function ifc_explorer_init_header() {
     const json_str = JSON.stringify(sgraph.header, null, 2);
     const container = document.createElement("pre");
@@ -450,6 +467,7 @@ function ifc_explorer_ifc_loaded() {
     ifc_explorer_init_decls();
     ifc_explorer_init_types();
     ifc_explorer_init_exprs();
+    ifc_explorer_init_files();
     ifc_explorer_init_header();
     ifc_explorer_init_toc();
 }

--- a/test/basic.cxx
+++ b/test/basic.cxx
@@ -359,7 +359,7 @@ namespace
         // No arguments.
         CHECK(null(func_decl.chart));
         CHECK(func_decl.traits == FunctionTraits::None);
-        CHECK(func_decl.basic_spec == (BasicSpecifiers::Cxx | BasicSpecifiers::External));
+        CHECK(func_decl.basic_spec == (BasicSpecifiers::Cxx));
         // Access only applies to class members.
         CHECK(func_decl.access == Access::None);
         // The function is defined in the module.
@@ -394,7 +394,76 @@ namespace
         CHECK(null(func_decl.chart));
         CHECK(func_decl.traits == FunctionTraits::None);
         // This is not exported
-        CHECK(func_decl.basic_spec == (BasicSpecifiers::Cxx | BasicSpecifiers::External | BasicSpecifiers::NonExported));
+        CHECK(func_decl.basic_spec == (BasicSpecifiers::Cxx | BasicSpecifiers::NonExported));
+        // Access only applies to class members.
+        CHECK(func_decl.access == Access::None);
+        // The function is defined in the module.
+        CHECK(func_decl.properties == ReachableProperties::Nothing);
+        // Type check.
+        REQUIRE(func_decl.type.sort() == TypeSort::Function);
+        auto& type = reader->get<symbolic::FunctionType>(func_decl.type);
+        CHECK(not null(type.target));
+        // This function takes no arguments.
+        CHECK(null(type.source));
+        CHECK(type.eh_spec.sort == NoexceptSort::None);
+        // This can change based on architecture compiled for.
+        const bool valid_calling = type.convention == CallingConvention::Cdecl or type.convention == CallingConvention::Std;
+        CHECK(valid_calling);
+
+        // Check return type.
+        check_fundamental_type(reader,
+                                type.target,
+                                make_fundamental_type(symbolic::TypeBasis::Void,
+                                                        symbolic::TypePrecision::Default,
+                                                        symbolic::TypeSign::Plain));
+    }
+
+    void check_glb_void_void_extern_func(Reader* reader, DeclIndex idx)
+    {
+        const auto sort = idx.sort();
+        REQUIRE(sort == DeclSort::Function);
+        auto& func_decl = reader->get<symbolic::FunctionDecl>(idx);
+        // This is a global function, the home_scope is null.
+        CHECK(null(func_decl.home_scope));
+        // No arguments.
+        CHECK(null(func_decl.chart));
+        CHECK(func_decl.traits == FunctionTraits::None);
+        CHECK(func_decl.basic_spec == (BasicSpecifiers::Cxx | BasicSpecifiers::External));
+        // Access only applies to class members.
+        CHECK(func_decl.access == Access::None);
+        // The function is defined in the module.
+        CHECK(func_decl.properties == ReachableProperties::Nothing);
+        // Type check.
+        REQUIRE(func_decl.type.sort() == TypeSort::Function);
+        auto& type = reader->get<symbolic::FunctionType>(func_decl.type);
+        CHECK(not null(type.target));
+        // This function takes no arguments.
+        CHECK(null(type.source));
+        CHECK(type.eh_spec.sort == NoexceptSort::None);
+        // This can change based on architecture compiled for.
+        const bool valid_calling = type.convention == CallingConvention::Cdecl or type.convention == CallingConvention::Std;
+        CHECK(valid_calling);
+
+        // Check return type.
+        check_fundamental_type(reader,
+                                type.target,
+                                make_fundamental_type(symbolic::TypeBasis::Void,
+                                                        symbolic::TypePrecision::Default,
+                                                        symbolic::TypeSign::Plain));
+    }
+
+    void check_glb_void_void_extern_func_not_exported(Reader* reader, DeclIndex idx)
+    {
+        const auto sort = idx.sort();
+        REQUIRE(sort == DeclSort::Function);
+        auto& func_decl = reader->get<symbolic::FunctionDecl>(idx);
+        // This is a global function, the home_scope is null.
+        CHECK(null(func_decl.home_scope));
+        // No arguments.
+        CHECK(null(func_decl.chart));
+        CHECK(func_decl.traits == FunctionTraits::None);
+        // This is not exported
+        CHECK(func_decl.basic_spec == (BasicSpecifiers::Cxx | BasicSpecifiers::NonExported | BasicSpecifiers::External));
         // Access only applies to class members.
         CHECK(func_decl.access == Access::None);
         // The function is defined in the module.
@@ -445,7 +514,7 @@ namespace
         CHECK(parm.properties == ReachableProperties::Nothing);
 
         CHECK(func_decl.traits == FunctionTraits::None);
-        CHECK(func_decl.basic_spec == (BasicSpecifiers::Cxx | BasicSpecifiers::External));
+        CHECK(func_decl.basic_spec == (BasicSpecifiers::Cxx));
         // Access only applies to class members.
         CHECK(func_decl.access == Access::None);
         // The function is defined in the module.
@@ -533,7 +602,7 @@ namespace
         }
 
         CHECK(func_decl.traits == FunctionTraits::None);
-        CHECK(func_decl.basic_spec == (BasicSpecifiers::Cxx | BasicSpecifiers::External));
+        CHECK(func_decl.basic_spec == (BasicSpecifiers::Cxx));
         // Access only applies to class members.
         CHECK(func_decl.access == Access::None);
         // The function is defined in the module.
@@ -750,6 +819,8 @@ TEST_CASE("IFC spec - decls")
     MatchingDeclSet expected_decls {
         { "glb_void_void_func", check_glb_void_void_func },
         { "glb_void_void_func_not_exported", check_glb_void_void_func_not_exported },
+        { "glb_void_void_extern_func", check_glb_void_void_extern_func },
+        { "glb_void_void_extern_func_not_exported", check_glb_void_void_extern_func_not_exported },
         { "glb_int_int_func", check_glb_int_int_func },
         { "glb_int_int_char_char_ptr_func", check_glb_int_int_char_char_ptr_func },
         { "FunctionTraits", check_function_traits },

--- a/test/m.ixx
+++ b/test/m.ixx
@@ -6,6 +6,11 @@ void glb_void_void_func();
 void glb_void_void_func_not_exported();
 
 export
+extern void glb_void_void_extern_func();
+
+extern void glb_void_void_extern_func_not_exported();
+
+export
 int glb_int_int_func(int);
 
 export


### PR DESCRIPTION
* Fix tests to better align with new compiler behavior.
  * FIXME: revisit this one the IFC has a better representation for the syntactic `extern` on function declarations vs compiler-generated/implicit external-linkage. #78
* Add visualizer update to show referenced source files in an IFC within its own tab in the explorer.