### PR TITLE
Add bcrypt.h include

### DIFF
--- a/src/hash_win.cxx
+++ b/src/hash_win.cxx
@@ -4,6 +4,7 @@
 // Windows Implementation of SHA256
 
 #include <windows.h>
+#include <bcrypt.h>
 #include <gsl/util>
 #include <ifc/file.hxx>
 #include <vector>


### PR DESCRIPTION
Add required include, discovered while compiling a portion of the IFC SDK in isolation