### PR TITLE
Add `DyadicOperator::Address`

### DIFF
--- a/include/ifc/operators.hxx
+++ b/include/ifc/operators.hxx
@@ -214,6 +214,7 @@ namespace ifc {
         ZeroInitialize,                     //                      -- abstract machine, zero-initialize an object or subject
         ClearStorage,                       //                      -- abstract machine, clear a storage span
         Select,                             // x :: y
+        Address,                            // &X::y for a non-static member y
 
         Msvc = 0x0400,
         MsvcTryCast,                        // WinRT try cast


### PR DESCRIPTION
Add a dedicated operator for a fully and semantically resolved pointer to non-static member (data or function).

[IFC-SPEC-157](https://github.com/microsoft/ifc-spec/pull/157)