### PR TITLE
Rename ExpressionListExpr::Delimiter::Unknown

### DIFF
--- a/include/ifc/abstract-sgraph.hxx
+++ b/include/ifc/abstract-sgraph.hxx
@@ -2786,9 +2786,9 @@ namespace ifc {
         // FIXME: Remove at earliest convenience.
         struct ExpressionListExpr : Tag<ExprSort::ExpressionList> {
             enum class Delimiter : uint8_t {
-                Unknown,
-                Brace,
-                Parenthesis,
+                None,               // No delimiter
+                Brace,              // Brace delimiters
+                Parenthesis,        // Parenthesis delimiters
             };
             SourceLocation left_delimiter{};  // The source location of the left delimiter
             SourceLocation right_delimiter{}; // The source location of the right delimiter

--- a/src/ifc-reader/util.cxx
+++ b/src/ifc-reader/util.cxx
@@ -233,8 +233,8 @@ namespace ifc::util {
         using Kind = symbolic::ExpressionListExpr::Delimiter;
         switch (delimiter)
         {
-        case Kind::Unknown:
-            return "Unknown";
+        case Kind::None:
+            return "None";
         case Kind::Brace:
             return "Brace";
         case Kind::Parenthesis:


### PR DESCRIPTION
Rename `ExpressionListExpr::Delimiter::Uknown` to `ExpressionListExpr::Delimiter::None` to align with IFC Spec naming (https://github.com/microsoft/ifc-spec/pull/158)