### PR TITLE
Bump release version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,14 @@
 # Copyright Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.28)
 
 # Corresponds to https://github.com/microsoft/ifc-spec
 set(ifc_spec_version 0.43)
 
 project(
     ifc-sdk
-    VERSION "${ifc_spec_version}.2"
+    VERSION "${ifc_spec_version}.5"
     LANGUAGES CXX
 )
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "microsoft-ifc-sdk",
-  "version-semver": "0.43.2",
+  "version-semver": "0.43.5",
   "dependencies": [
     "ms-gsl",
     "doctest"


### PR DESCRIPTION
- Bump IFC SDK release version to 0.43.5
- Require CMake 3.28 or higher