### PR TITLE
`ifc-printer` should use `wmain` on Windows

### DIFF
--- a/include/ifc/tooling.hxx
+++ b/include/ifc/tooling.hxx
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <string>
 #include <filesystem>
+#include <vector>
 
 namespace ifc {
     // Filesystem component.  Forward to standard facilities.

--- a/src/ifc-printer/main.cxx
+++ b/src/ifc-printer/main.cxx
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <fstream>
 #include <cstdlib>
+#include <vector>
 #include "ifc/tooling.hxx"
 #include "ifc/reader.hxx"
 #include "ifc/dom/node.hxx"


### PR DESCRIPTION
This patch makes `ifc-printer` use `wmain` on windows.